### PR TITLE
A box must have homogeneous checks

### DIFF
--- a/example/src/main/scala/com/criteo/slab/example/GraphiteLauncher.scala
+++ b/example/src/main/scala/com/criteo/slab/example/GraphiteLauncher.scala
@@ -3,16 +3,16 @@ package com.criteo.slab.example
 import java.time.Duration
 
 import com.criteo.slab.app.WebServer
-import com.criteo.slab.lib.graphite.GraphiteStore
+import com.criteo.slab.lib.graphite.{GraphiteStore, GraphiteCodecs}
 import org.slf4j.LoggerFactory
-import com.criteo.slab.lib.graphite.GraphiteCodecs
 
 object GraphiteLauncher {
-  val logger = LoggerFactory.getLogger(this.getClass)
 
   import scala.concurrent.ExecutionContext.Implicits.global
   import SimpleBoard._
   import GraphiteCodecs._
+
+  val logger = LoggerFactory.getLogger(this.getClass)
 
   def main(args: Array[String]): Unit = {
     val maybeStore = for {

--- a/example/src/main/scala/com/criteo/slab/example/Launcher.scala
+++ b/example/src/main/scala/com/criteo/slab/example/Launcher.scala
@@ -14,7 +14,7 @@ object Launcher {
   import scala.concurrent.ExecutionContext.Implicits.global
 
   // You should provide codec for checked value types for values to be persistent in a store
-  import InMemoryStore._
+  import InMemoryStore.codec
 
   def main(args: Array[String]): Unit = {
     // Define a value store for uploading and restoring history

--- a/src/main/scala/com/criteo/slab/core/Board.scala
+++ b/src/main/scala/com/criteo/slab/core/Board.scala
@@ -1,6 +1,6 @@
 package com.criteo.slab.core
 
-import shapeless.{HList, HNil, LUBConstraint}
+import shapeless.{HList, UnaryTCConstraint}
 
 /** Top level component
   *
@@ -12,10 +12,10 @@ import shapeless.{HList, HNil, LUBConstraint}
   */
 case class Board[B <: HList](
                               title: String,
-                              boxes: B = HNil,
+                              boxes: B,
                               aggregate: (Map[Box[_], View], Context) => View,
                               layout: Layout,
                               links: Seq[(Box[_], Box[_])] = Seq.empty
                             )(
-                              implicit constraint: LUBConstraint[B, Box[_]]
+                              implicit constraint: UnaryTCConstraint[B, Box]
                             )

--- a/src/main/scala/com/criteo/slab/core/Box.scala
+++ b/src/main/scala/com/criteo/slab/core/Box.scala
@@ -3,7 +3,6 @@ package com.criteo.slab.core
 import com.criteo.slab.utils.Jsonable
 import org.json4s.CustomSerializer
 import org.json4s.JsonDSL._
-import shapeless.{HList, LUBConstraint}
 
 /** A box that groups checks
   *
@@ -12,29 +11,28 @@ import shapeless.{HList, LUBConstraint}
   * @param aggregate   Aggregates the views of its checks, return a view
   * @param description The description of the box in markdown syntax
   * @param labelLimit  The limit of visible check labels shown on the box
+  * @tparam T The type bound to the checks
   */
-case class Box[C <: HList](
-                            title: String,
-                            checks: C,
-                            aggregate: (Map[Check[_], View], Context) => View,
-                            description: Option[String] = None,
-                            labelLimit: Option[Int] = None
-                          )(
-                            implicit constraints: LUBConstraint[C, Check[_]]
-                          )
-
+case class Box[T](
+                   title: String,
+                   checks: Seq[Check[T]],
+                   aggregate: (Map[Check[T], View], Context) => View,
+                   description: Option[String] = None,
+                   labelLimit: Option[Int] = None
+                 )
 
 object Box {
+
   implicit object toJSON extends Jsonable[Box[_]] {
     override val serializers = List(Ser)
 
-    object Ser extends CustomSerializer[Box[_]](_ => ( {
+    object Ser extends CustomSerializer[Box[_]](_ => ({
       case _ => throw new NotImplementedError("Not deserializable")
     }, {
       case box: Box[_] =>
         ("title" -> box.title) ~ ("description" -> box.description) ~ ("labelLimit" -> box.labelLimit.getOrElse(64))
-    }
-    ))
+    }))
 
   }
+
 }

--- a/src/main/scala/com/criteo/slab/core/Check.scala
+++ b/src/main/scala/com/criteo/slab/core/Check.scala
@@ -8,7 +8,7 @@ import scala.concurrent.Future
   * @param title   The title of the check
   * @param apply   A function when called, should return a future of target value
   * @param display A function that takes a checked value and a [[com.criteo.slab.core.Context Context]]
-  * @tparam T A type parameter which corresponds to the type of the checked value
+  * @tparam T The type of values to be checked
   */
 case class Check[T](
                      id: String,

--- a/src/main/scala/com/criteo/slab/core/Executor.scala
+++ b/src/main/scala/com/criteo/slab/core/Executor.scala
@@ -38,13 +38,13 @@ private[slab] object Executor {
     implicit def f[L <: HList, A <: HList, B <: HList](
                                                         implicit
                                                         zip: ZipConst.Aux[(Context, Boolean), L, A],
-                                                        mapper: Mapper.Aux[GoBox.type, A, B],
+                                                        mapper: Mapper.Aux[RunBox.type, A, B],
                                                         to: ToTraversable.Aux[B, List, Future[(Box[_], BoxView)]],
                                                         ec: ExecutionContext
                                                       ): Case.Aux[Board[L], Context, Boolean, Future[BoardView]] =
       at { (board, context, isReplay) =>
         Future.sequence {
-          board.boxes.zipConst(context -> isReplay).map(GoBox).toList[Future[(Box[_], BoxView)]]
+          board.boxes.zipConst(context -> isReplay).map(RunBox).toList[Future[(Box[_], BoxView)]]
         } map { pairs =>
           val bv = pairs.toMap
           val aggView = board.aggregate(bv.mapValues(_.toView), context)
@@ -53,21 +53,19 @@ private[slab] object Executor {
       }
   }
 
-  object GoBox extends Poly1 {
-    implicit def f[L <: HList, A <: HList, B <: HList](
-                                                        implicit
-                                                        zip: ZipConst.Aux[Context, L, A],
-                                                        mapper: Mapper.Aux[GoCheck.type, A, B],
-                                                        mapper2: Mapper.Aux[ReplayCheck.type, A, B],
-                                                        to: ToTraversable.Aux[B, List, Future[(Check[_], CheckView)]],
-                                                        ec: ExecutionContext
-                                                      ): Case.Aux[(Box[L], (Context, Boolean)), Future[(Box[_], BoxView)]] =
+  object RunBox extends Poly1 {
+    implicit def f[T, Repr](
+                             implicit
+                             ec: ExecutionContext,
+                             store: Store[Repr],
+                             codec: Codec[T, Repr]
+                           ): Case.Aux[(Box[T], (Context, Boolean)), Future[(Box[T], BoxView)]] =
       at { case (box, (context, isReplay)) =>
         Future.sequence {
           if (isReplay)
-            box.checks.zipConst(context).map(ReplayCheck).toList[Future[(Check[_], CheckView)]]
+            box.checks.map(replayCheck(_, context))
           else
-            box.checks.zipConst(context).map(GoCheck).toList[Future[(Check[_], CheckView)]]
+            box.checks.map(runCheck(_, context))
         } map { pairs =>
           val cv = pairs.toMap
           val aggView = box.aggregate(cv.mapValues(_.toView), context)
@@ -76,67 +74,62 @@ private[slab] object Executor {
       }
   }
 
-  object GoCheck extends Poly1 {
-    implicit def f[T, R](
-                          implicit
-                          store: Store[R],
-                          codec: Codec[T, R],
-                          ec: ExecutionContext
-                        ): Case.Aux[(Check[T], Context), Future[(Check[T], CheckView)]] =
-      at { case (check, context) =>
-        check
-          .apply()
-          .flatMap(value =>
-            store
-              .upload(check.id, context, value)
-              .map(_ => value)
-              .recover {
-                case e =>
-                  logger.error(e.getMessage, e)
-                  value
-              }
-          )
-          .map(check.display(_, context))
-          .recover {
-            case e =>
-              logger.error(e.getMessage, e)
-              View(Status.Unknown, e.getMessage)
-          }
-          .map(view => (check, CheckView(check.title, view.status, view.message)))
-      }
-  }
-
-  object ReplayCheck extends Poly1 {
-    implicit def f[T, R](
-                          implicit
-                          store: Store[R],
-                          codec: Codec[T, R],
-                          ec: ExecutionContext
-                        ): Case.Aux[(Check[T], Context), Future[(Check[T], CheckView)]] =
-      at { case (check, context) =>
+  def runCheck[T, Repr](check: Check[T], context: Context)(
+    implicit
+    store: Store[Repr],
+    codec: Codec[T, Repr],
+    ec: ExecutionContext
+  ) = {
+    check
+      .apply()
+      .flatMap(value =>
         store
-          .fetch(check.id, context)
-          .map(check.display(_, context))
+          .upload(check.id, context, value)
+          .map(_ => value)
           .recover {
             case e =>
               logger.error(e.getMessage, e)
-              View(Status.Unknown, e.getMessage)
+              value
           }
-          .map(view => (check, CheckView(check.title, view.status, view.message)))
+      )
+      .map(check.display(_, context))
+      .recover {
+        case e =>
+          logger.error(e.getMessage, e)
+          View(Status.Unknown, e.getMessage)
       }
+      .map(view => (check, CheckView(check.title, view.status, view.message)))
   }
 
+  def replayCheck[T, Repr](check: Check[T], context: Context)(
+    implicit
+    store: Store[Repr],
+    codec: Codec[T, Repr],
+    ec: ExecutionContext
+  ) = {
+    store
+      .fetch(check.id, context)
+      .map(check.display(_, context))
+      .recover {
+        case e =>
+          logger.error(e.getMessage, e)
+          View(Status.Unknown, e.getMessage)
+      }
+      .map(view => (check, CheckView(check.title, view.status, view.message)))
+  }
+
+  // History
   object FetchBoardHistory extends Poly3 {
     implicit def f[L <: HList, A <: HList, B <: HList](
                                                         implicit
                                                         zipConst: ZipConst.Aux[(Instant, Instant), L, A],
                                                         mapper: Mapper.Aux[FetchBoxHistory.type, A, B],
-                                                        toTraversable: ToTraversable.Aux[B, List, Future[Box[_ <: HList] Tuple2 Seq[(Long, BoxView)]]],
+                                                        toTraversable: ToTraversable.Aux[B, List, Future[Box[_] Tuple2 Seq[(Long, BoxView)]]],
                                                         ec: ExecutionContext
                                                       ): Case.Aux[Board[L], Instant, Instant, Future[Seq[(Long, BoardView)]]] =
       at { (board, from, until) =>
         Future.sequence {
-          board.boxes.zipConst((from, until)).map(FetchBoxHistory).toList[Future[Box[_ <: HList] Tuple2 Seq[(Long, BoxView)]]]
+          board.boxes.zipConst((from, until)).map(FetchBoxHistory).toList[Future[Box[_] Tuple2 Seq[(Long, BoxView)]]]
         }.map { boxes =>
           boxes.flatMap { case (box, boxViews) =>
             boxViews.map { case (ts, view) =>
@@ -152,49 +145,52 @@ private[slab] object Executor {
   }
 
   object FetchBoxHistory extends Poly1 {
-    implicit def f[L <: HList, A <: HList, B <: HList, R](
-                                                           implicit
-                                                           store: Store[R],
-                                                           zipConst: ZipConst.Aux[(Instant, Instant), L, A],
-                                                           mapper: Mapper.Aux[FetchCheckHistory.type, A, B],
-                                                           toTraversable: ToTraversable.Aux[B, List, Future[Check[_] Tuple2 Seq[(Long, CheckView)]]],
-                                                           ec: ExecutionContext
-                                                         ): Case.Aux[Box[L] Tuple2 (Instant, Instant), Future[Box[L] Tuple2 Seq[(Long, BoxView)]]] =
+    implicit def f[T, Repr](
+                             implicit
+                             store: Store[Repr],
+                             codec: Codec[T, Repr],
+                             ec: ExecutionContext
+                           ): Case.Aux[Box[T] Tuple2 (Instant, Instant), Future[Box[T] Tuple2 Seq[(Long, BoxView)]]] =
       at { case (box, (from, until)) =>
-        Future.sequence {
-          box.checks.zipConst((from, until)).map(FetchCheckHistory).toList[Future[Check[_] Tuple2 Seq[(Long, CheckView)]]]
-        } map { checks =>
-          box -> checks
-            .flatMap { case (check, checkViews) =>
-              checkViews.map { case (ts, view) =>
-                (ts, (check, view))
-              }.groupBy(_._1).map { case (ts, xs) =>
-                val checkViews = xs.map(_._2)
-                val aggView = box.aggregate(checkViews.toMap[Check[_], CheckView].mapValues(_.toView), Context(Instant.ofEpochMilli(ts)))
-                (ts, BoxView(box.title, aggView.status, aggView.message, checkViews.map(_._2)))
-              }
-            }
+        fetchBoxHistory(box, from, until)
+      }
+  }
+
+  def fetchBoxHistory[T, Repr](box: Box[T], from: Instant, until: Instant)(
+    implicit
+    store: Store[Repr],
+    codec: Codec[T, Repr],
+    ec: ExecutionContext
+  ) = {
+    Future.sequence {
+      box.checks.map(fetchCheckHistory(_, from, until))
+    } map { checks =>
+      box -> checks
+        .flatMap { case (check, checkViews) =>
+          checkViews.map { case (ts, view) =>
+            (ts, (check, view))
+          }.groupBy(_._1).map { case (ts, xs) =>
+            val checkViews = xs.map(_._2)
+            val aggView = box.aggregate(checkViews.toMap[Check[T], CheckView].mapValues(_.toView), Context(Instant.ofEpochMilli(ts)))
+            (ts, BoxView(box.title, aggView.status, aggView.message, checkViews.map(_._2)))
+          }
         }
-      }
+    }
   }
 
-  object FetchCheckHistory extends Poly1 {
-    implicit def f[T, R](
-                          implicit
-                          store: Store[R],
-                          codec: Codec[T, R],
-                          ec: ExecutionContext
-                        ): Case.Aux[Check[T] Tuple2 (Instant, Instant), Future[Check[T] Tuple2 Seq[(Long, CheckView)]]] =
-      at { case (check, (from, until)) =>
-        store
-          .fetchHistory[T](check.id, from, until)
-          .map(series =>
-            check -> series.map { case (ts, value) =>
-              val view = check.display(value, Context(Instant.ofEpochMilli(ts)))
-              (ts, CheckView(check.title, view.status, view.message, view.label))
-            }
-          )
-      }
+  def fetchCheckHistory[T, Repr](check: Check[T], from: Instant, until: Instant)(
+    implicit
+    store: Store[Repr],
+    codec: Codec[T, Repr],
+    ec: ExecutionContext
+  ) = {
+    store
+      .fetchHistory[T](check.id, from, until)
+      .map(series =>
+        check -> series.map { case (ts, value) =>
+          val view = check.display(value, Context(Instant.ofEpochMilli(ts)))
+          (ts, CheckView(check.title, view.status, view.message, view.label))
+        }
+      )
   }
-
 }

--- a/src/main/scala/com/criteo/slab/core/package.scala
+++ b/src/main/scala/com/criteo/slab/core/package.scala
@@ -1,0 +1,6 @@
+package com.criteo.slab
+
+import shapeless.{HNil => SHNil}
+package object core {
+  def HNil = SHNil
+}

--- a/src/main/scala/com/criteo/slab/lib/graphite/GraphiteCodecs.scala
+++ b/src/main/scala/com/criteo/slab/lib/graphite/GraphiteCodecs.scala
@@ -13,7 +13,7 @@ import scala.util.Try
   */
 object GraphiteCodecs {
 
-  implicit def latencyCodec = new Codec[Latency, Repr] {
+  implicit val latencyCodec = new Codec[Latency, Repr] {
     override def encode(v: Latency): Repr = Map(
       "latency" -> v.underlying
     )
@@ -23,7 +23,7 @@ object GraphiteCodecs {
     }
   }
 
-  implicit def version = new Codec[Version, Repr] {
+  implicit val version = new Codec[Version, Repr] {
     override def encode(v: Version): Repr = Map(
       "version" -> v.underlying
     )
@@ -33,7 +33,7 @@ object GraphiteCodecs {
     )
   }
 
-  implicit def instant = new Codec[Instant, Repr] {
+  implicit val instant = new Codec[Instant, Repr] {
     override def encode(v: Instant): Repr = Map(
       "datetime" -> v.toEpochMilli
     )

--- a/src/main/scala/com/criteo/slab/package.scala
+++ b/src/main/scala/com/criteo/slab/package.scala
@@ -1,5 +1,5 @@
 package com.criteo
 
-/** API doc for Slab
+/** Slab API documentation
   */
 package object slab

--- a/src/test/scala/com/criteo/slab/core/ExecutorSpec.scala
+++ b/src/test/scala/com/criteo/slab/core/ExecutorSpec.scala
@@ -10,71 +10,99 @@ class ExecutorSpec extends FlatSpec with Matchers with FutureTests with BeforeAn
   override def beforeEach = {
     reset(spiedCheck1)
     reset(spiedCheck2)
+    reset(spiedCheck3)
   }
+
   val executor = Executor(board)
   "apply" should "fetch current check values if no context is given" in {
+    val boardView = BoardView(
+      "board",
+      Status.Unknown,
+      "board message",
+      List(
+        BoxView(
+          "box 1",
+          Status.Success,
+          "box 1 message",
+          List(
+            CheckView(
+              "check 1",
+              Status.Success,
+              "check 1 message: new value"
+            ),
+            CheckView(
+              "check 2",
+              Status.Success,
+              "check 2 message: new value"
+            )
+          )
+        ),
+        BoxView(
+          "box 2",
+          Status.Success,
+          "box 2 message",
+          List(
+            CheckView(
+              "check 3",
+              Status.Success,
+              "check 3 message: 3"
+            )
+          )
+        )
+      )
+    )
     val f = executor.apply(None)
     whenReady(f) { res =>
       verify(spiedCheck1, times(1)).apply
       verify(spiedCheck2, times(1)).apply
-      res shouldEqual BoardView(
-        "board",
-        Status.Unknown,
-        "board message",
-        List(
-          BoxView(
-            "box 1",
-            Status.Success,
-            "box 1 message",
-            List(
-              CheckView(
-                "check 1",
-                Status.Success,
-                "check 1 message"
-              ),
-              CheckView(
-                "check 2",
-                Status.Success,
-                "check 2 message: new value"
-              )
-            )
-          )
-        )
-      )
+      verify(spiedCheck3, times(1)).apply
+      res shouldEqual boardView
     }
   }
 
   "apply" should "fetch past check values if a context is given" in {
-    val f = executor.apply(Some(Context(Instant.now)))
-    reset(spiedCheck1)
-    reset(spiedCheck2)
-    whenReady(f) { res =>
-      verify(spiedCheck1, never).apply
-      verify(spiedCheck2, never).apply
-      res shouldEqual BoardView(
-        "board",
-        Status.Unknown,
-        "board message",
-        List(
-          BoxView(
-            "box 1",
-            Status.Success,
-            "box 1 message",
-            List(
-              CheckView(
-                "check 1",
-                Status.Success,
-                "check 1 message"
-              ),
-              CheckView(
-                "check 2",
-                Status.Success,
-                "check 2 message: 100"
-              )
+    val boardView = BoardView(
+      "board",
+      Status.Unknown,
+      "board message",
+      List(
+        BoxView(
+          "box 1",
+          Status.Success,
+          "box 1 message",
+          List(
+            CheckView(
+              "check 1",
+              Status.Success,
+              "check 1 message: 100"
+            ),
+            CheckView(
+              "check 2",
+              Status.Success,
+              "check 2 message: 100"
+            )
+          )
+        ),
+        BoxView(
+          "box 2",
+          Status.Success,
+          "box 2 message",
+          List(
+            CheckView(
+              "check 3",
+              Status.Success,
+              "check 3 message: 100"
             )
           )
         )
       )
+    )
+    val f = executor.apply(Some(Context(Instant.now)))
+    whenReady(f) { res =>
+      verify(spiedCheck1, never).apply
+      verify(spiedCheck2, never).apply
+      verify(spiedCheck3, never).apply
+      res shouldEqual boardView
     }
   }
 }

--- a/src/test/scala/com/criteo/slab/core/LayoutSpec.scala
+++ b/src/test/scala/com/criteo/slab/core/LayoutSpec.scala
@@ -2,14 +2,13 @@ package com.criteo.slab.core
 
 import com.criteo.slab.utils.Jsonable._
 import org.scalatest.{FlatSpec, Matchers}
-import shapeless.HNil
 
 class LayoutSpec extends FlatSpec with Matchers {
 
   "Layout" should "be serializable to JSON" in {
     val layout = Layout(List(
       Column(50, List(Row("A", 25, List(
-        Box("box1", check1::HNil, (vs, _) => vs.head._2)
+        Box[String]("box1", check1::Nil, (vs, _) => vs.head._2)
       ))))
     ))
     layout.toJSON shouldEqual """{"columns":[{"percentage":50.0,"rows":[{"title":"A","percentage":25.0,"boxes":[{"title":"box1","labelLimit":64}]}]}]}"""

--- a/src/test/scala/com/criteo/slab/core/package.scala
+++ b/src/test/scala/com/criteo/slab/core/package.scala
@@ -2,7 +2,6 @@ package com.criteo.slab
 
 import java.time.Instant
 
-import com.criteo.slab.core._
 import shapeless.HNil
 
 import scala.concurrent.Future
@@ -10,30 +9,43 @@ import scala.util.Try
 import org.mockito.Mockito._
 
 package object core {
-  val check1 = Check[Int](
+  val check1 = Check[String](
     "c.1",
     "check 1",
-    () => Future.successful(1),
-    (_, _) => View(Status.Success, "check 1 message")
+    () => Future.successful("new value"),
+    (value, _) => View(Status.Success, s"check 1 message: $value")
   )
   val check2 = Check[String](
     "c.2",
     "check 2",
     () => Future.successful("new value"),
-    (value, _) => View(Status.Success, "check 2 message: " + value)
+    (value, _) => View(Status.Success, s"check 2 message: $value")
+  )
+  val check3 = Check[Int](
+    "c.3",
+    "check 3",
+    () => Future.successful(3),
+    (value, _) => View(Status.Success, s"check 3 message: $value")
   )
   val spiedCheck1 = spy(check1)
   val spiedCheck2 = spy(check2)
+  val spiedCheck3 = spy(check3)
 
-  val box = Box(
+  val box1 = Box[String](
     "box 1",
-    spiedCheck1::spiedCheck2::HNil,
-    (views, _) => views.get(spiedCheck1).getOrElse(View(Status.Unknown, "unknown")).copy(message = "box 1 message")
+    List(spiedCheck1, spiedCheck2),
+    (views, _) => views.get(spiedCheck2).getOrElse(View(Status.Unknown, "unknown")).copy(message = "box 1 message")
+  )
+
+  val box2 = Box[Int](
+    "box 2",
+    List(spiedCheck3),
+    (views, _) => views.values.head.copy(message = "box 2 message")
   )
 
   val board = Board(
     "board",
-    box::HNil,
+    box1::box2::HNil,
     (_, _) => View(Status.Unknown, "board message"),
     Layout(
       List.empty


### PR DESCRIPTION
- now each box is type-parameterized with all children checks bound to that type

I find this solution a reasonable trade-off based on my observations from working with existing dashboards:
- In most cases, people create boxes that have all checks being the same type, often collections are used to create such checks, making checks HList renders it very hard to work with
- People do create boxes of different types, but don't need to do anything more than putting them on a board, so making boxes HList increases zero complexity while the advantage of codec independence is kept

As a result, this solution adapts well all existing boards and requires trivial changes, and users don't need to touch `shapeless` at all, see `example`