### PR TITLE
Simplify Layout definition syntax

### DIFF
--- a/example/src/main/scala/com/criteo/slab/example/SimpleBoard.scala
+++ b/example/src/main/scala/com/criteo/slab/example/SimpleBoard.scala
@@ -84,23 +84,21 @@ object SimpleBoard {
   // Define the layout of the board
   lazy val layout = Layout(
     // Define 3 columns, each takes 33.3% of the width of the board
-    Seq(Column(
+    Column(
       33.3,
       // We put the web server box in this row
-      Seq(Row("Tier 1", 100, Seq(webService)))
-    ), Column(
+      Row("Tier 1", 100, Seq(webService))
+    ),
+    Column(
       33.3,
       // Define two rows, each row takes 50% of the height of the column
-      Seq(
-        Row("Tier 2 - 1", 50, Seq(gateway)),
-        Row("Tier 2 - 2", 50, Seq(pipelineZeta, pipelineOmega))
-      )
-    ), Column(
+      Row("Tier 2 - 1", 50, Seq(gateway)),
+      Row("Tier 2 - 2", 50, Seq(pipelineZeta, pipelineOmega))
+    ),
+    Column(
       33.3,
-      Seq(
-        Row("Tier 3", 100, Seq(databaseKappa, ui))
-      )
-    ))
+      Row("Tier 3", 100, Seq(databaseKappa, ui))
+    )
   )
 
   // Create a board

--- a/src/main/scala/com/criteo/slab/core/Layout.scala
+++ b/src/main/scala/com/criteo/slab/core/Layout.scala
@@ -8,7 +8,7 @@ import org.json4s.Serializer
   * @param percentage The percentage it takes as width
   * @param rows The rows in the column
   */
-case class Column(percentage: Double, rows: Seq[Row])
+case class Column(percentage: Double, rows: Row*)
 
 /** Represents a row inside a column
   *
@@ -22,7 +22,7 @@ case class Row(title: String, percentage: Double = 100, boxes: Seq[Box[_]])
   *
   * @param columns List of [[Column]]
   */
-case class Layout(columns: Seq[Column])
+case class Layout(columns: Column*)
 
 object Layout {
 

--- a/src/test/scala/com/criteo/slab/core/BoardSpec.scala
+++ b/src/test/scala/com/criteo/slab/core/BoardSpec.scala
@@ -18,10 +18,10 @@ class BoardSpec extends FlatSpec with Matchers with MockitoSugar {
         box1 :: HNil,
         (views, _) => views.values.head,
         Layout(
-          Seq(Column(
+          Column(
             100,
-            Seq(Row("row", 10, box2 :: Nil))
-          ))
+            Row("row", 10, box2 :: Nil)
+          )
         )
       )
     }
@@ -31,10 +31,10 @@ class BoardSpec extends FlatSpec with Matchers with MockitoSugar {
         box1 :: box2 :: HNil,
         (views, _) => views.values.head,
         Layout(
-          Seq(Column(
+          Column(
             100,
-            Seq(Row("row", 10, List.empty))
-          ))
+            Row("row", 10, List.empty)
+          )
         )
       )
     }

--- a/src/test/scala/com/criteo/slab/core/LayoutSpec.scala
+++ b/src/test/scala/com/criteo/slab/core/LayoutSpec.scala
@@ -6,11 +6,11 @@ import org.scalatest.{FlatSpec, Matchers}
 class LayoutSpec extends FlatSpec with Matchers {
 
   "Layout" should "be serializable to JSON" in {
-    val layout = Layout(List(
-      Column(50, List(Row("A", 25, List(
-        Box[String]("box1", check1::Nil, (vs, _) => vs.head._2)
-      ))))
-    ))
+    val layout = Layout(
+      Column(50, Row("A", 25, List(
+        Box[String]("box1", check1 :: Nil, (vs, _) => vs.head._2)
+      )))
+    )
     layout.toJSON shouldEqual """{"columns":[{"percentage":50.0,"rows":[{"title":"A","percentage":25.0,"boxes":[{"title":"box1","labelLimit":64}]}]}]}"""
   }
 }

--- a/src/test/scala/com/criteo/slab/core/package.scala
+++ b/src/test/scala/com/criteo/slab/core/package.scala
@@ -48,13 +48,13 @@ package object core {
     box1 :: box2 :: HNil,
     (_, _) => View(Status.Unknown, "board message"),
     Layout(
-      List(
-        Column(50, List(
-          Row("r1", 100, List(box1))
-        )),
-        Column(50, List(
-          Row("r2", 100, List(box2))
-        ))
+      Column(
+        50,
+        Row("r1", 100, List(box1))
+      ),
+      Column(
+        50,
+        Row("r2", 100, List(box2))
       )
     )
   )


### PR DESCRIPTION
- Too many parentheses is not good for eye health, let's use varargs