### PR TITLE
Fix box scrolling on Firefox and Chrome 72+

### DIFF
--- a/src/main/webapp/style/components/BoxModal.styl
+++ b/src/main/webapp/style/components/BoxModal.styl
@@ -33,6 +33,7 @@
     flex: 1
     flex-direction: column
     padding: 1em 2em
+    min-height: 0
     > h3 {
       font-weight: 500
       margin-bottom: .5em


### PR DESCRIPTION
- The \<main\> element containing the checks has a nonzero min height, and
completely covers the checks, preventing scrolling
- See spec at https://drafts.csswg.org/css-flexbox/#min-size-auto